### PR TITLE
warn users if javascript is disabled

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -11,6 +11,7 @@
 <body>
 	<div id="h"><img src="l.svg" class="svg"></div>
 	<div id="main">
+		<noscript><h1>Please enable javascript!</h1></noscript>
 		<h1>Available files:</h1>
 		<table id="fileidx" class="c t">
 			<thead>


### PR DESCRIPTION
Saw a reddit post where a user was confused why his phone wasn't loading the file list correctly.  It seems like javascript was just disabled.  I figured a quick noscript tag would clear this up for future users.