### PR TITLE
Improved sizing of file manager on mobile

### DIFF
--- a/html/credits.html
+++ b/html/credits.html
@@ -1,9 +1,11 @@
 <html>
 <head><title>Credits</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
+	<img src="l.svg" class="svg">
 <div id="main">
 <h2>Credits</h2>
 <p>This is the Chooser, (c) 2017 pocketsprite.com.</p>
@@ -33,5 +35,6 @@ and licensed under the Apache 2.0 License.</p>
 to <a href="https://pocketsprite.com/sources">https://pocketsprite.com/sources</a>.</p>
 
 </div>
+<div class="cr"><a href="/">Back</a></div>
 </body>
 

--- a/html/index.html
+++ b/html/index.html
@@ -3,13 +3,14 @@
 <head>
 	<title>Pocket Sprite File Manager</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<link rel="stylesheet" type="text/css" href="style.css">
 	<script type="text/javascript" src="140medley.min.js"></script>
 	<script type="text/javascript" src="main.js"></script>
 </head>
 
 <body>
-	<div id="h"><img src="l.svg" class="svg"></div>
+	<img src="l.svg" class="svg">
 	<div id="main">
 		<noscript><h1>Please enable javascript!</h1></noscript>
 		<table width=100%>

--- a/html/style.css
+++ b/html/style.css
@@ -1,27 +1,31 @@
 html, body {
-	min-height: 100%;
-	font-family: sans-serif;
-	font-size: 1.5vw;
 	-moz-user-select: none;
 	-webkit-user-select: none;
 	user-select: none;
+	margin: 0;
+	padding: 0;
+	width: 100%;
+	min-height: 100%;
+}
+html {
+	font-family: sans-serif;
+	font-size: 1.5vw;
 }
 body {
-	margin: 10px;
 	color: #fff;
 	background-color: rgba(25, 31, 41, 1);
 	background-image: linear-gradient(to bottom, rgba(25, 31, 41, 1) 0%, rgba(233, 65, 82, 1) 100%);
 	background-size: cover;
 	background-repeat: repeat-x;
-}
-
-#h {
 	text-align: center;
-	margin: 2em;
+	padding: 1rem 0;
 }
 
-#h img {
-	width: 50%;
+
+.svg {
+	max-width: 50%;
+	height: auto;
+	margin: 2rem auto;
 }
 
 a {
@@ -49,11 +53,12 @@ h1 {
 	padding: 2em;
 	padding-bottom: 2.2em;
 	box-shadow: 8px 8px 0px rgba(0, 0, 0, 0.5);
+	text-align: left;
 }
 
 .c {
 	background-color: #1f1f1f;
-	border-radius: 8px;
+	border-radius: 1rem;
 }
 
 .t {
@@ -138,6 +143,7 @@ button:focus {
 	height: 2rem;
 	width: 100%;
 	overflow: hidden;
+	display: none;
 }
 
 #progressbarinner {
@@ -155,6 +161,7 @@ button:focus {
 	margin: auto;
 	width: 50%;
 	text-align: center;
+	font-size: 1rem;
 }
 
 .cr a {
@@ -179,5 +186,11 @@ button:focus {
 	}
 	#main {
 		width: 90%;
+	}
+	.form {
+		flex-direction: column;
+	}
+	.form > * {
+		margin-bottom: 1rem;
 	}
 }

--- a/html/style.css
+++ b/html/style.css
@@ -143,7 +143,6 @@ button:focus {
 	height: 2rem;
 	width: 100%;
 	overflow: hidden;
-	display: none;
 }
 
 #progressbarinner {


### PR DESCRIPTION
Just another small CSS/HTML tweak, this makes the html pages use the `<meta name="viewport" content="width=device-width, initial-scale=1" />` tag and some accompanying CSS so that everything looks good on mobile devices.

I've also improved the Credits page a bit, adding the Pocket Sprite logo and a link back to the file manager.