### PR TITLE
Clean up keylock, add battery indicator

### DIFF
--- a/main/gui.c
+++ b/main/gui.c
@@ -38,6 +38,24 @@ void drawIcon(int px, int py, int o) {
 	}
 }
 
+void drawBatterySOC() {
+	// draw outer battery frame
+	UG_DrawFrame(KC_SCREEN_W-21, 0, KC_SCREEN_W-3, 7, C_WHITE);
+	UG_DrawFrame(KC_SCREEN_W-2, 2, KC_SCREEN_W-1, 5, C_WHITE);
+	
+	// collect battery info
+	int b = kchal_get_bat_pct();
+	
+	// select appropriate filler color
+	UG_COLOR batColor;
+	if (b < 20) batColor = C_RED;
+	else if (b < 50) batColor = C_GOLD;
+	else batColor = C_LIME;
+	
+	// fill in battery, relative to battery SOC
+	UG_FillFrame(KC_SCREEN_W-20, 1, KC_SCREEN_W-4-(((100-b)*16)/100), 6, batColor);
+}
+
 
 void guiCharging(int almostFull) {
 	kcugui_cls();
@@ -77,19 +95,7 @@ void guiSplash() {
 
 	UG_FontSelect(&FONT_6X8);
 	
-	char buf[32];
-	int b = kchal_get_bat_pct();
-	//int b = 100;
-	sprintf(buf, "%i", b);
-
-	if (b < 20) UG_SetForecolor(C_RED);
-	else if (b < 50) UG_SetForecolor(C_GOLD);
-	else UG_SetForecolor(C_LAWN_GREEN);
-	
-	UG_PutString(KC_SCREEN_W-4-(7*strlen(buf)), 1, buf);
-
-	UG_DrawFrame(KC_SCREEN_W-27, 0, KC_SCREEN_W-3, 8, C_WHITE);
-	UG_DrawFrame(KC_SCREEN_W-2, 2, KC_SCREEN_W-1, 6, C_WHITE);
+	drawBatterySOC();
 	
 	if (wifi_en) {
 		UG_SetForecolor(C_WHITE);
@@ -102,7 +108,7 @@ void guiSplash() {
 		UG_PutString(0, 32, "HTTP://192.168.4.1/");
 	} else {
 		UG_SetForecolor(C_WHITE);
-		UG_PutString(0, 8,  "NOTE:      ");
+		UG_PutString(0, 8,  "   NOTE:");
 		UG_SetForecolor(C_YELLOW);
 		UG_PutString(0, 16, "WiFi is off");
 		UG_PutString(0, 24, "and can be ");
@@ -110,6 +116,8 @@ void guiSplash() {
 		UG_PutString(0, 40, "the options");
 		UG_PutString(0, 48, "menu.      ");
 	}
+	UG_SetForecolor(C_RED);
+	UG_PutString(30, 56, "MENU");
 	UG_SetBackcolor(C_BLACK);
 
 	kcugui_flush();

--- a/main/gui.c
+++ b/main/gui.c
@@ -40,8 +40,8 @@ void drawIcon(int px, int py, int o) {
 
 void drawBatterySOC() {
 	// draw outer battery frame
-	UG_DrawFrame(KC_SCREEN_W-21, 0, KC_SCREEN_W-3, 7, C_WHITE);
-	UG_DrawFrame(KC_SCREEN_W-2, 2, KC_SCREEN_W-1, 5, C_WHITE);
+	UG_DrawFrame(KC_SCREEN_W-17, 0, KC_SCREEN_W-3, 6, C_WHITE);
+	UG_DrawFrame(KC_SCREEN_W-2, 2, KC_SCREEN_W-1, 4, C_WHITE);
 	
 	// collect battery info
 	int b = kchal_get_bat_pct();
@@ -53,7 +53,7 @@ void drawBatterySOC() {
 	else batColor = C_LIME;
 	
 	// fill in battery, relative to battery SOC
-	UG_FillFrame(KC_SCREEN_W-20, 1, KC_SCREEN_W-4-(((100-b)*16)/100), 6, batColor);
+	UG_FillFrame(KC_SCREEN_W-16, 1, KC_SCREEN_W-4-(((100-b)*12)/100), 5, batColor);
 }
 
 
@@ -93,28 +93,27 @@ void guiSplash() {
 	}
 	nvs_close(nvsHandle);
 
-	UG_FontSelect(&FONT_6X8);
-	
 	drawBatterySOC();
 	
+	UG_FontSelect(&FONT_6X8);
 	if (wifi_en) {
 		UG_SetForecolor(C_WHITE);
-		UG_PutString(0, 8, "WIFI AP");
+		UG_PutString(0, 0, "WIFI AP");
 		UG_SetForecolor(C_YELLOW);
-		UG_PutString(0, 16, " pkspr");
+		UG_PutString(0, 8, " pkspr");
 		UG_SetForecolor(C_WHITE);
-		UG_PutString(0, 24, "GO TO:");
+		UG_PutString(0, 16, "GO TO:");
 		UG_SetForecolor(C_YELLOW);
-		UG_PutString(0, 32, "HTTP://192.168.4.1/");
+		UG_PutString(0, 24, "HTTP://192.168.4.1/");
 	} else {
 		UG_SetForecolor(C_WHITE);
-		UG_PutString(0, 8,  "   NOTE:");
+		UG_PutString(0, 0, "   NOTE:");
 		UG_SetForecolor(C_YELLOW);
-		UG_PutString(0, 16, "WiFi is off");
-		UG_PutString(0, 24, "and can be ");
-		UG_PutString(0, 32, "enabled in ");
-		UG_PutString(0, 40, "the options");
-		UG_PutString(0, 48, "menu.      ");
+		UG_PutString(0, 8,  "WiFi is off");
+		UG_PutString(0, 16, "and can be ");
+		UG_PutString(0, 24, "enabled in ");
+		UG_PutString(0, 32, "the options");
+		UG_PutString(0, 40, "menu.      ");
 	}
 	UG_SetForecolor(C_RED);
 	UG_PutString(30, 56, "MENU");

--- a/main/gui.c
+++ b/main/gui.c
@@ -63,6 +63,10 @@ void guiBatEmpty() {
 
 void guiInit() {
 	kcugui_init();
+	kcugui_flush();
+}
+
+void guiSplash() {
 	uint8_t wifi_en=1;
 	nvs_handle nvsHandle=NULL;
 	esp_err_t r=nvs_open("8bkc", NVS_READONLY, &nvsHandle);

--- a/main/gui.c
+++ b/main/gui.c
@@ -76,27 +76,40 @@ void guiSplash() {
 	nvs_close(nvsHandle);
 
 	UG_FontSelect(&FONT_6X8);
+	
+	char buf[32];
+	int b = kchal_get_bat_pct();
+	//int b = 100;
+	sprintf(buf, "%i", b);
+
+	if (b < 20) UG_SetForecolor(C_RED);
+	else if (b < 50) UG_SetForecolor(C_GOLD);
+	else UG_SetForecolor(C_LAWN_GREEN);
+	
+	UG_PutString(KC_SCREEN_W-4-(7*strlen(buf)), 1, buf);
+
+	UG_DrawFrame(KC_SCREEN_W-27, 0, KC_SCREEN_W-3, 8, C_WHITE);
+	UG_DrawFrame(KC_SCREEN_W-2, 2, KC_SCREEN_W-1, 6, C_WHITE);
+	
 	if (wifi_en) {
 		UG_SetForecolor(C_WHITE);
-		UG_PutString(0, 0, "WIFI AP");
+		UG_PutString(0, 8, "WIFI AP");
 		UG_SetForecolor(C_YELLOW);
-		UG_PutString(0, 8, " pkspr");
+		UG_PutString(0, 16, " pkspr");
 		UG_SetForecolor(C_WHITE);
-		UG_PutString(0, 16, "GO TO:");
+		UG_PutString(0, 24, "GO TO:");
 		UG_SetForecolor(C_YELLOW);
-		UG_PutString(0, 24, "HTTP://192.168.4.1/");
+		UG_PutString(0, 32, "HTTP://192.168.4.1/");
 	} else {
 		UG_SetForecolor(C_WHITE);
-		UG_PutString(0, 0, "   NOTE:");
+		UG_PutString(0, 8,  "NOTE:      ");
 		UG_SetForecolor(C_YELLOW);
-		UG_PutString(0, 8,  "WiFi is off");
-		UG_PutString(0, 16, "and can be ");
-		UG_PutString(0, 24, "enabled in ");
-		UG_PutString(0, 32, "the options");
-		UG_PutString(0, 40, "menu.      ");
+		UG_PutString(0, 16, "WiFi is off");
+		UG_PutString(0, 24, "and can be ");
+		UG_PutString(0, 32, "enabled in ");
+		UG_PutString(0, 40, "the options");
+		UG_PutString(0, 48, "menu.      ");
 	}
-	UG_SetForecolor(C_RED);
-	UG_PutString(30, 56, "MENU");
 	UG_SetBackcolor(C_BLACK);
 
 	kcugui_flush();

--- a/main/gui.h
+++ b/main/gui.h
@@ -7,6 +7,7 @@ void guiFull();
 void guiBatEmpty();
 
 void guiInit();
+void guiSplash();
 
 void guiMenu();
 

--- a/main/main.c
+++ b/main/main.c
@@ -291,6 +291,7 @@ int app_main(void)
 	httpdInit(builtInUrls, 80);
 
 	guiInit();
+	guiSplash();
 
 	printf("\nReady\n");
 


### PR DESCRIPTION
Right now, the main chooser menu (wifi info / wifi disabled text) appears briefly before the keylock text.

This is kind of disorienting, and I find myself messing up the keylock input often (too early, then I press again too late).

This fix only prints the main chooser menu when we want it (`app_main()`), not during other scenarios (recovery, charging, keylock)