### PR TITLE
Fix brief flash during keylock

### DIFF
--- a/main/gui.c
+++ b/main/gui.c
@@ -63,6 +63,10 @@ void guiBatEmpty() {
 
 void guiInit() {
 	kcugui_init();
+	kcugui_flush();
+}
+
+void guiSplash() {
 	uint8_t wifi_en=1;
 	nvs_handle nvsHandle=NULL;
 	esp_err_t r=nvs_open("8bkc", NVS_READONLY, &nvsHandle);

--- a/main/gui.h
+++ b/main/gui.h
@@ -7,6 +7,7 @@ void guiFull();
 void guiBatEmpty();
 
 void guiInit();
+void guiSplash();
 
 void guiMenu();
 

--- a/main/main.c
+++ b/main/main.c
@@ -295,6 +295,7 @@ int app_main(void)
 	httpdInit(builtInUrls, 80);
 
 	guiInit();
+	guiSplash();
 
 	printf("\nReady, AP on channel %d\n", (int)channel);
 


### PR DESCRIPTION
Right now, the main chooser menu (wifi info / wifi disabled text) appears briefly before the keylock text.

This is kind of disorienting, and I find myself messing up the keylock input often (too early, then I press again too late).  Then I have to wait a second to retry the unlock.

This fix only prints the main chooser menu when we want it (`app_main()`), not during other scenarios (recovery, charging, keylock)