### PR TITLE
Protect screen from charge burn-in with timeout

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -107,6 +107,19 @@ void handleCharging() {
 	guiInit();
 	guiCharging();
 
+	uint8_t timeout=false;
+	time_t now;
+	time_t maxTimeout=5;
+	nvs_handle nvsHandle=NULL;
+	if (nvs_open("8bkc", NVS_READWRITE, &nvsHandle)==ESP_OK) {
+		nvs_get_u8(nvsHandle, "timeout", &timeout);
+	}
+
+	if(timeout) {
+		time(&now);
+		maxTimeout+=now;
+	}
+
 	//Disable app cpu
 	DPORT_SET_PERI_REG_MASK(DPORT_APPCPU_CTRL_B_REG, DPORT_APPCPU_CLKGATE_EN);
 	//Speed down
@@ -114,16 +127,26 @@ void handleCharging() {
 
 	do {
 		r=kchal_get_chg_status();
-		if (r==KC_CHG_FULL || fixFull) {
-			guiFull();
-			printf("Full!\n");
-			fullCtr++;
-		} else if (r==KC_CHG_CHARGING) {
-			guiCharging(kchal_get_bat_mv()>4100);
-			printf("Charging...\n");
-			fullCtr=0;
-		}
+		if(timeout) {
+			time(&now);
 
+			if(now > maxTimeout) {
+				kcugui_cls();
+				kcugui_flush();
+			}
+		}
+		else {
+			if (r==KC_CHG_FULL || fixFull) {
+				guiFull();
+				printf("Full!\n");
+				fullCtr++;
+			}
+			else if (r==KC_CHG_CHARGING) {
+				guiCharging(kchal_get_bat_mv() > 4100);
+				printf("Charging...\n");
+				fullCtr = 0;
+			}
+		}
 		if (kchal_get_keys() & KC_BTN_POWER) {
 			rtc_clk_cpu_freq_set(RTC_CPU_FREQ_80M);
 			printf("Power btn pressed; restarting with override bit set\n");


### PR DESCRIPTION
This pull request adds an option to the settings menu simply called timeout.
After enabling this option, the screen goes blank when charging/charged after five seconds have passed.